### PR TITLE
feat: add onComplete callback to IncremarkContent across all frameworks

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -26,6 +26,17 @@ The main component for rendering Markdown content.
 | `devtoolsId` | `string` | *Auto-generated* | Unique identifier for this parser in DevTools. |
 | `devtoolsLabel` | `string` | `devtoolsId` | Display label for this parser in DevTools. |
 
+**Events / Callbacks**:
+
+Fired when the content is fully displayed (the typewriter animation has finished, or parsing has completed when the typewriter is disabled). The callback receives the full markdown string. Naming follows each framework's convention:
+
+| Framework | Usage |
+|-----------|-------|
+| React | `onComplete={(markdown) => {}}` |
+| Vue | `@complete="(markdown) => {}"` |
+| Solid | `onComplete={(markdown) => {}}` |
+| Svelte | `oncomplete={(markdown) => {}}` |
+
 ### `<AutoScrollContainer />`
 
 A container that automatically scrolls to the bottom when content updates.

--- a/docs/zh/api/index.md
+++ b/docs/zh/api/index.md
@@ -26,6 +26,17 @@ Incremark 所有类型和组件的集中参考。
 | `devtoolsId` | `string` | *自动生成* | 在 DevTools 中此解析器的唯一标识符。 |
 | `devtoolsLabel` | `string` | `devtoolsId` | 在 DevTools 中此解析器的显示标签。 |
 
+**事件 / 回调**：
+
+内容完全显示完成时触发（打字机动画播放结束；未启用打字机时则为解析完成）。回调参数为完整的 markdown 字符串。命名遵循各框架的惯例：
+
+| 框架 | 用法 |
+|------|------|
+| React | `onComplete={(markdown) => {}}` |
+| Vue | `@complete="(markdown) => {}"` |
+| Solid | `onComplete={(markdown) => {}}` |
+| Svelte | `oncomplete={(markdown) => {}}` |
+
 ### `<AutoScrollContainer />`
 
 当内容更新时自动滚动到底部的容器组件。

--- a/packages/react/src/components/IncremarkContent.tsx
+++ b/packages/react/src/components/IncremarkContent.tsx
@@ -41,7 +41,8 @@ export const IncremarkContent: React.FC<IncremarkContentProps> = (props) => {
     pendingClass,
     devtools,
     devtoolsId,
-    devtoolsLabel
+    devtoolsLabel,
+    onComplete
   } = props
 
   // 初始化时使用的选项（使用 ref 保存，只用于首次创建 parser）
@@ -167,6 +168,15 @@ export const IncremarkContent: React.FC<IncremarkContentProps> = (props) => {
       finalize()
     }
   }, [isFinished, content, markdown, finalize])
+
+  // 监听内容显示完成（打字机动画结束或解析完成），仅在 false→true 跳变时触发
+  const prevDisplayCompleteRef = useRef(isDisplayComplete)
+  useEffect(() => {
+    if (isDisplayComplete && !prevDisplayCompleteRef.current) {
+      onComplete?.(markdown)
+    }
+    prevDisplayCompleteRef.current = isDisplayComplete
+  }, [isDisplayComplete, markdown, onComplete])
 
   return (
     <IncremarkContainerProvider definitions={_definitionsContextValue}>

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -33,4 +33,6 @@ export interface IncremarkContentProps {
   devtoolsId?: string
   /** DevTools 中显示的 parser 标签，默认使用 ID */
   devtoolsLabel?: string
+  /** 内容完全显示完成时触发（打字机动画播放结束或解析完成），参数为完整 markdown */
+  onComplete?: (markdown: string) => void
 }

--- a/packages/solid/src/components/IncremarkContent.tsx
+++ b/packages/solid/src/components/IncremarkContent.tsx
@@ -1,6 +1,6 @@
 /* @jsxImportSource solid-js */
 
-import { Component, createEffect, createMemo, onMount, onCleanup } from 'solid-js'
+import { Component, createEffect, createMemo, onMount, onCleanup, untrack } from 'solid-js'
 import type { JSX } from 'solid-js'
 import { useIncremark } from '../composables/useIncremark'
 import type { IncremarkContentProps } from '../types'
@@ -94,6 +94,16 @@ export const IncremarkContent: Component<IncremarkContentProps> = (props) => {
     if (newIsFinished && props.content === markdown()) {
       finalize()
     }
+  })
+
+  // 监听内容显示完成（打字机动画结束或解析完成），仅在 false→true 跳变时触发
+  let prevDisplayComplete = isDisplayComplete()
+  createEffect(() => {
+    const complete = isDisplayComplete()
+    if (complete && !prevDisplayComplete) {
+      untrack(() => props.onComplete?.(markdown()))
+    }
+    prevDisplayComplete = complete
   })
 
   return (

--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -36,4 +36,6 @@ export interface IncremarkContentProps {
   devtoolsId?: string
   /** DevTools 中显示的 parser 标签，默认使用 ID */
   devtoolsLabel?: string
+  /** 内容完全显示完成时触发（打字机动画播放结束或解析完成），参数为完整 markdown */
+  onComplete?: (markdown: string) => void
 }

--- a/packages/svelte/src/components/IncremarkContent.svelte
+++ b/packages/svelte/src/components/IncremarkContent.svelte
@@ -23,7 +23,8 @@
     showBlockStatus = false,
     devtools,
     devtoolsId,
-    devtoolsLabel
+    devtoolsLabel,
+    oncomplete
   }: IncremarkContentProps = $props()
 
   // 创建 incremark 实例（只创建一次）
@@ -147,6 +148,16 @@
     if (isFinished && content === incremark.markdown) {
       incremark.finalize()
     }
+  })
+
+  // 监听内容显示完成（打字机动画结束或解析完成），仅在 false→true 跳变时触发
+  let prevDisplayComplete = untrack(() => incremark.isDisplayComplete)
+  $effect(() => {
+    const complete = incremark.isDisplayComplete
+    if (complete && !prevDisplayComplete) {
+      oncomplete?.(untrack(() => incremark.markdown))
+    }
+    prevDisplayComplete = complete
   })
 </script>
 

--- a/packages/svelte/src/components/types.ts
+++ b/packages/svelte/src/components/types.ts
@@ -50,5 +50,7 @@ export interface IncremarkContentProps {
   devtoolsId?: string
   /** DevTools 中显示的 parser 标签，默认使用 ID */
   devtoolsLabel?: string
+  /** 内容完全显示完成时触发（打字机动画播放结束或解析完成），参数为完整 markdown */
+  oncomplete?: (markdown: string) => void
 }
 

--- a/packages/vue/src/components/IncremarkContent.vue
+++ b/packages/vue/src/components/IncremarkContent.vue
@@ -7,6 +7,11 @@
 
   const props = defineProps<IncremarkContentProps>()
 
+  const emit = defineEmits<{
+    /** 内容完全显示完成时触发（打字机动画播放结束或解析完成），参数为完整 markdown */
+    complete: [markdown: string]
+  }>()
+
   const incremarkOptions = computed(() => ({
     gfm: true,
     htmlTree: true,
@@ -87,6 +92,13 @@
       finalize();
     }
   }, { immediate: true })
+
+  // 监听内容显示完成（打字机动画结束或解析完成），仅在 false→true 跳变时触发
+  watch(isDisplayComplete, (newVal, oldVal) => {
+    if (newVal && !oldVal) {
+      emit('complete', markdown.value);
+    }
+  })
 </script>
 
 <template>

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -1,4 +1,4 @@
-export type { IncremarkContentProps } from '../types'
+export type { IncremarkContentProps, IncremarkContentEmits } from '../types'
 // 主组件
 export { default as Incremark } from './Incremark.vue'
 export { default as IncremarkContent } from '../components/IncremarkContent.vue'

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -34,3 +34,11 @@ export interface IncremarkContentProps {
   /** DevTools 中显示的 parser 标签，默认使用 ID */
   devtoolsLabel?: string
 }
+
+/**
+ * IncremarkContent 组件事件
+ */
+export interface IncremarkContentEmits {
+  /** 内容完全显示完成时触发（打字机动画播放结束或解析完成），参数为完整 markdown */
+  (e: 'complete', markdown: string): void
+}


### PR DESCRIPTION
## Summary

- Add `onComplete` callback to `IncremarkContent` component across React, Vue, Solid, and Svelte packages.
- Fires when content is fully displayed (typewriter animation finished, or parsing completed when typewriter is disabled).
- Follows each framework's naming convention: React/Solid `onComplete`, Vue `@complete` event, Svelte `oncomplete`.
- Export `IncremarkContentEmits` type from Vue package for external consumers.
- Update API docs (EN/ZH) with the new event documentation.

## Testing

- Not run (not requested)

Closes #18
